### PR TITLE
(I don't want to write a title)

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -810,6 +810,12 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
         return 0;
     }
 
+    // FIXME: dafuq?
+    // free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
+    SQLFreeStmt(cursor->hstmt, SQL_CLOSE);
+    SQLFreeStmt(cursor->hstmt, SQL_CLOSE); // FIXME: dafuq? why do I have to call it twice?
+    SQLFreeStmt(cursor->hstmt, SQL_RESET_PARAMS);
+
     PyObject* pProcName = PyTuple_GET_ITEM(args, 0);
 
     if (!PyString_Check(pProcName) && !PyUnicode_Check(pProcName))
@@ -992,6 +998,13 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
     }
     pyodbc_free(pszParameterList);
 
+    // FIXME: what about SQL_RESET_PARAMS?
+    //
+    // SQLFreeStmt(cursor->hstmt, SQL_CLOSE);
+    // SQLFreeStmt(cursor->hstmt, SQL_CLOSE);
+    // SQLFreeStmt(((Cursor*)self)->hstmt, SQL_CLOSE);
+    //
+    // SQLFreeStmt(cursor->hstmt, SQL_RESET_PARAMS);
     return pReturn;
 }
 

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -881,7 +881,7 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
         else
 #endif
         {
-            SQLWChar query(pCallStatement);
+            SQLWChar query(pCallStatement); // FIXME: pCallStatement is not a unicode object.
             if (!query)
                 return 0;
 

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -814,7 +814,7 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
     // free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
     SQLFreeStmt(cursor->hstmt, SQL_CLOSE);
     SQLFreeStmt(cursor->hstmt, SQL_CLOSE); // FIXME: dafuq? why do I have to call it twice?
-    SQLFreeStmt(cursor->hstmt, SQL_RESET_PARAMS);
+    // SQLFreeStmt(cursor->hstmt, SQL_RESET_PARAMS); // FIXME: when this is needed?
 
     PyObject* pProcName = PyTuple_GET_ITEM(args, 0);
 

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -811,7 +811,7 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
     }
 
     free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
-    free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
+    free_results(cursor, FREE_STATEMENT | KEEP_PREPARED); // FIXME
 
     PyObject* pProcName = PyTuple_GET_ITEM(args, 0);
     if (!PyString_Check(pProcName) && !PyUnicode_Check(pProcName))

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -810,10 +810,7 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
         return 0;
     }
 
-    // FIXME: dafuq?
-    // free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
-    SQLFreeStmt(cursor->hstmt, SQL_CLOSE);
-    SQLFreeStmt(cursor->hstmt, SQL_CLOSE); // FIXME: dafuq? why do I have to call it twice?
+    free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
 
     PyObject* pProcName = PyTuple_GET_ITEM(args, 0);
     if (!PyString_Check(pProcName) && !PyUnicode_Check(pProcName))

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -811,7 +811,7 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
     }
 
     free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
-    free_results(cursor, FREE_STATEMENT | KEEP_PREPARED); // FIXME
+    free_results(cursor, FREE_STATEMENT | KEEP_PREPARED); // FIXME: why?
 
     PyObject* pProcName = PyTuple_GET_ITEM(args, 0);
     if (!PyString_Check(pProcName) && !PyUnicode_Check(pProcName))
@@ -897,7 +897,7 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
         else
 #endif
         {
-            SQLWChar query(pCallStatement); // FIXME: pCallStatement is not a unicode object.
+            SQLWChar query(pCallStatement);
             if (!query)
                 return 0;
 

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -811,6 +811,7 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
     }
 
     free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
+    free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
 
     PyObject* pProcName = PyTuple_GET_ITEM(args, 0);
     if (!PyString_Check(pProcName) && !PyUnicode_Check(pProcName))

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -814,11 +814,14 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
     // free_results(cursor, FREE_STATEMENT | KEEP_PREPARED);
     SQLFreeStmt(cursor->hstmt, SQL_CLOSE);
     SQLFreeStmt(cursor->hstmt, SQL_CLOSE); // FIXME: dafuq? why do I have to call it twice?
-    // SQLFreeStmt(cursor->hstmt, SQL_RESET_PARAMS); // FIXME: when this is needed?
 
     PyObject* pProcName = PyTuple_GET_ITEM(args, 0);
+    if (!PyString_Check(pProcName) && !PyUnicode_Check(pProcName))
+    {
+        PyErr_SetString(PyExc_TypeError, "The first argument to callproc must be a string or unicode stored procedure name.");
+        return 0;
+    }
 
-    // FIXME: incref/decref?
     bool paramsInTuple = false;
     if (cParams > 0) {
         PyObject *t = PyTuple_GET_ITEM(args, 1);
@@ -831,12 +834,6 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
             }
             cParams = PyTuple_Size(args);
         }
-    }
-
-    if (!PyString_Check(pProcName) && !PyUnicode_Check(pProcName))
-    {
-        PyErr_SetString(PyExc_TypeError, "The first argument to callproc must be a string or unicode stored procedure name.");
-        return 0;
     }
 
     // Construct the call statement.
@@ -1013,13 +1010,6 @@ static PyObject* Cursor_callproc(PyObject* self, PyObject* args)
     }
     pyodbc_free(pszParameterList);
 
-    // FIXME: what about SQL_RESET_PARAMS?
-    //
-    // SQLFreeStmt(cursor->hstmt, SQL_CLOSE);
-    // SQLFreeStmt(cursor->hstmt, SQL_CLOSE);
-    // SQLFreeStmt(((Cursor*)self)->hstmt, SQL_CLOSE);
-    //
-    // SQLFreeStmt(cursor->hstmt, SQL_RESET_PARAMS);
     return pReturn;
 }
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -184,6 +184,10 @@ static bool GetBytesInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamIn
     Py_ssize_t len = PyBytes_GET_SIZE(param);
 
 #if PY_MAJOR_VERSION >= 3
+
+// oh yeah.
+#error "pyodbc-callproc doesn't support python3 yet"
+
     info.ValueType = SQL_C_BINARY;
     info.ColumnSize = (SQLUINTEGER)max(len, 1);
 
@@ -217,7 +221,7 @@ static bool GetBytesInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamIn
         // Too long to pass all at once, so we'll provide the data at execute.
         info.ParameterType     = SQL_LONGVARCHAR;
         info.StrLen_or_Ind     = cur->cnxn->need_long_data_len ? SQL_LEN_DATA_AT_EXEC((SQLLEN)len) : SQL_DATA_AT_EXEC;
-        info.ParameterValuePtr = param; // FIXME: dafuq? incref again?
+        info.ParameterValuePtr = param;
     }
 #endif
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -280,7 +280,8 @@ static bool GetBooleanInfo(Cursor* cur, Py_ssize_t index, PyObject* param, Param
     return true;
 }
 
-static PyObject* ToDateTimeInfo(const ParamInfo* info) {
+static PyObject* ToDateTimeInfo(const ParamInfo* info)
+{
     // each unit in fraction is one billionth of one second. python uses microsecond instead.
     const TIMESTAMP_STRUCT *p = &(info->Data.timestamp);
     return PyDateTime_FromDateAndTime(p->year, p->month,  p->day, p->hour, p->minute, p->second, p->fraction / 1000);
@@ -323,7 +324,8 @@ static bool GetDateTimeInfo(Cursor* cur, Py_ssize_t index, PyObject* param, Para
     return true;
 }
 
-static PyObject* ToDateInfo(const ParamInfo* info) {
+static PyObject* ToDateInfo(const ParamInfo* info)
+{
     return PyDate_FromDate(info->Data.date.year, info->Data.date.month, info->Data.date.day);
 }
 
@@ -343,7 +345,8 @@ static bool GetDateInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInf
     return true;
 }
 
-static PyObject* ToTimeInfo(const ParamInfo* info) {
+static PyObject* ToTimeInfo(const ParamInfo* info)
+{
     return PyTime_FromTime(info->Data.time.hour, info->Data.time.minute, info->Data.time.second, 0);
 }
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -222,6 +222,9 @@ static bool GetBytesInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamIn
                 ostr_len = (int)len;
             }
             void *buf = (void *)malloc(ostr_len + 1);
+            if (buf == NULL) {
+                return false;
+            }
             if (info.InputOutputType == SQL_PARAM_INPUT_OUTPUT) {
                 memcpy(buf, PyBytes_AS_STRING(param), len + 1);
             } else {
@@ -294,6 +297,13 @@ static bool GetUnicodeInfo(Cursor* cur, Py_ssize_t index, PyObject* param, Param
     return true;
 }
 
+static PyObject* ToBooleanInfo(const ParamInfo* info)
+{
+    PyObject *o = info->Data.ch ? Py_True : Py_False;
+    Py_INCREF(o);
+    return o;
+}
+
 static bool GetBooleanInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInfo& info)
 {
     info.ValueType         = SQL_C_BIT;
@@ -301,6 +311,7 @@ static bool GetBooleanInfo(Cursor* cur, Py_ssize_t index, PyObject* param, Param
     info.StrLen_or_Ind     = 1;
     info.Data.ch           = (unsigned char)(param == Py_True ? 1 : 0);
     info.ParameterValuePtr = &info.Data.ch;
+    info.fnToPyObject = ToBooleanInfo;
     return true;
 }
 
@@ -440,6 +451,11 @@ static bool GetLongInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInf
     return true;
 }
 
+static PyObject* ToFloatInfo(const ParamInfo* info)
+{
+    return PyFloat_FromDouble(info->Data.dbl);
+}
+
 static bool GetFloatInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInfo& info)
 {
     // TODO: Overflow?
@@ -451,6 +467,7 @@ static bool GetFloatInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamIn
     info.StrLen_or_Ind     = sizeof(info.Data.dbl);
     info.BufferLength      = sizeof(info.Data.dbl);
     info.ColumnSize = 15;
+    info.fnToPyObject = ToFloatInfo;
     return true;
 }
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -221,7 +221,7 @@ static bool GetBytesInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamIn
             if (ostr_len < len) {
                 ostr_len = (int)len;
             }
-            void *buf = (void *)malloc(ostr_len + 1);
+            void *buf = malloc(ostr_len + 1);
             if (buf == NULL) {
                 return false;
             }
@@ -252,47 +252,160 @@ static bool GetBytesInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamIn
     return true;
 }
 
-static bool GetUnicodeInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInfo& info)
+// SQL Server uses UCS-2 for nvarchar/ntext.
+//
+// this is copied and modified from PyUnicode_FromSQLWCHAR in sqlwchar.cpp
+static PyObject* PyUnicode_FromUCS2(const char* p, Py_ssize_t cch)
+{
+    // Create a Python Unicode object from a zero-terminated SQLWCHAR.
+    if (2 == Py_UNICODE_SIZE)
+    {
+        // The ODBC Unicode and Python Unicode types are the same size.  Cast the ODBC type to the Python type and use
+        // a fast function.
+        return PyUnicode_FromUnicode((const Py_UNICODE*)p, cch);
+    }
+    
+#ifdef HAVE_WCHAR_H
+    if (sizeof(wchar_t) == 2)
+    {
+        // The ODBC Unicode is the same as wchar_t.  Python provides a function for that.
+        return PyUnicode_FromWideChar((const wchar_t*)p, cch);
+    }
+#endif
+
+    // There is no conversion, so we will copy it ourselves with a simple cast.
+
+    // I don't believe in any case Py_UNICODE_SIZE could be smaller than 2.
+    // So I think just copy without checking would be fine.
+    
+    Object result(PyUnicode_FromUnicode(0, cch));
+    if (!result)
+        return 0;
+
+    Py_UNICODE* pch = PyUnicode_AS_UNICODE(result.Get());
+    for (Py_ssize_t i = 0; i < cch; i++)
+        pch[i] = (Py_UNICODE)p[i];
+    
+    return result.Detach();
+}
+
+
+static PyObject* ToUnicodeInfo(const ParamInfo* info) {
+    // // FIXME
+    printf("buff len: %ld\n", info->StrLen_or_Ind);
+    printf("sizeof(SQLWCHAR): %ld\n", sizeof(SQLWCHAR));
+    printf("sizeof(Py_UNICODE): %ld\n", sizeof(Py_UNICODE));
+    // for (int i = 0; i < info->StrLen_or_Ind / sizeof(SQLWCHAR); i++) {
+    //     printf("> (%lx)\n", (unsigned long)((SQLWCHAR*)(info->ParameterValuePtr))[i]);
+    // }
+    for (int i = 0; i < info->StrLen_or_Ind; i++) {
+        printf("> (%hx)\n", (unsigned short)((unsigned char*)(info->ParameterValuePtr))[i]);
+    }
+    // Py_INCREF(Py_None);
+    // return Py_None;
+    // return PyUnicode_FromSQLWCHAR((const SQLWCHAR*)info->ParameterValuePtr, info->StrLen_or_Ind / sizeof(SQLWCHAR));
+    return PyUnicode_FromUCS2((const char*)info->ParameterValuePtr, info->StrLen_or_Ind / 2);
+}
+
+static bool GetUnicodeInfo(Cursor* cur, Py_ssize_t index, PyObject* param, ParamInfo& info, int ostr_len)
 {
     Py_UNICODE* pch = PyUnicode_AsUnicode(param);
     Py_ssize_t  len = PyUnicode_GET_SIZE(param);
+
+    printf("GetUnicodeInfo.len: %d\n", (int)len); // FIXME
+
+    { // FIXME
+        printf("input PyUnicode:\n");
+        for (int i = 0; i < len*sizeof(Py_UNICODE); i++) {
+            printf("> (%hx)\n", (unsigned short)((unsigned char *)pch)[i]);
+        }
+        printf("=====\n");
+    }
 
     info.ValueType  = SQL_C_WCHAR;
     info.ColumnSize = (SQLUINTEGER)max(len, 1);
 
     if (len <= cur->cnxn->wvarchar_maxlength)
     {
-        if (SQLWCHAR_SIZE == Py_UNICODE_SIZE)
-        {
-            info.ParameterValuePtr = pch;
-        }
-        else
-        {
-            // SQLWCHAR and Py_UNICODE are not the same size, so we need to allocate and copy a buffer.
-            if (len > 0)
-            {
-                info.ParameterValuePtr = SQLWCHAR_FromUnicode(pch, len);
-                if (info.ParameterValuePtr == 0)
-                    return false;
-                info.allocated = true;
-            }
-            else
-            {
-                info.ParameterValuePtr = pch;
-            }
-        }
+        // if (SQLWCHAR_SIZE == Py_UNICODE_SIZE)
+        // {
+        //     info.ParameterValuePtr = pch;
+        // }
+        // else
+        // {
+        //     // SQLWCHAR and Py_UNICODE are not the same size, so we need to allocate and copy a buffer.
+        //     if (len > 0)
+        //     {
+        //         info.ParameterValuePtr = SQLWCHAR_FromUnicode(pch, len);
+        //         if (info.ParameterValuePtr == 0)
+        //             return false;
+        //         info.allocated = true;
+        //     }
+        //     else
+        //     {
+        //         info.ParameterValuePtr = pch;
+        //     }
+        // }
 
-        info.ParameterType = SQL_WVARCHAR;
-        info.StrLen_or_Ind = (SQLINTEGER)(len * sizeof(SQLWCHAR));
+        // info.ParameterType = SQL_WVARCHAR;
+        // info.StrLen_or_Ind = (SQLINTEGER)(len * sizeof(SQLWCHAR));
+
+        if (info.InputOutputType == SQL_PARAM_INPUT) {
+            info.ParameterType = SQL_WVARCHAR;
+            info.StrLen_or_Ind = (SQLINTEGER)(len * sizeof(SQLWCHAR));
+            info.BufferLength = info.StrLen_or_Ind + sizeof(SQLWCHAR);
+            if (SQLWCHAR_SIZE == Py_UNICODE_SIZE) {
+                info.ParameterValuePtr = pch;
+            } else {
+                info.ParameterValuePtr = SQLWCHAR_FromUnicode(pch, len);
+                info.allocated = true;
+                { // FIXME
+                    // FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME
+                    for (int i = 0; i < 8; i++) {
+                        memcpy((char*)info.ParameterValuePtr + i*2, (char*)info.ParameterValuePtr + i*4, 2);
+                    }
+                    memset((char*)info.ParameterValuePtr + 8*2, 0, 2);
+                    // FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME FIXME
+
+                    printf("converted input SQLWCHAR sequence:\n");
+                    for (int i = 0; i < len*sizeof(SQLWCHAR); i++) {
+                        printf("> (%hx)\n", (unsigned short)((unsigned char*)(info.ParameterValuePtr))[i]);
+                    }
+                    printf("=====\n");
+                }
+            }
+
+            printf("SQLBindParameter:\n");
+            printf("    ColumnSize=%d\n    BufferLength=%d\n    *StrLen_or_IndPtr=%d\n", info.ColumnSize, info.BufferLength, info.StrLen_or_Ind);
+        } else {
+            if (ostr_len < len) {
+                ostr_len = (int)len;
+            }
+            info.ParameterType = SQL_WVARCHAR;
+            info.ColumnSize    = ostr_len;
+            info.ParameterValuePtr = SQLWCHAR_FromUnicode(pch, len, ostr_len); // FIXME: copying not required for OUTPUT
+            info.StrLen_or_Ind = (SQLINTEGER)(len * sizeof(SQLWCHAR));
+            info.BufferLength  = (SQLINTEGER)((ostr_len + 1) * sizeof(SQLWCHAR));
+            info.allocated = true;
+            info.fnToPyObject = ToUnicodeInfo;
+            { // FIXME
+                printf("converted SQLWCHAR sequence:\n");
+                for (int i = 0; i < len; i++) {
+                    printf("> (%lx)\n", (unsigned long)((SQLWCHAR*)(info.ParameterValuePtr))[i]);
+                }
+                printf("=====\n");
+            }
+        }
     }
     else
     {
         // Too long to pass all at once, so we'll provide the data at execute.
-
         info.ParameterType     = SQL_WLONGVARCHAR;
         info.StrLen_or_Ind     = cur->cnxn->need_long_data_len ? SQL_LEN_DATA_AT_EXEC((SQLLEN)len * sizeof(SQLWCHAR)) : SQL_DATA_AT_EXEC;
         info.ParameterValuePtr = param;
+        // FIXME: fnToPyObject?
     }
+
 
     return true;
 }
@@ -696,7 +809,7 @@ static bool GetParameterInfo(Cursor* cur, Py_ssize_t index, PyObject* param, Par
         return GetBooleanInfo(cur, index, info.pParam, info);
 
     if (PyUnicode_Check(info.pParam))
-        return GetUnicodeInfo(cur, index, info.pParam, info);
+        return GetUnicodeInfo(cur, index, info.pParam, info, ostr_len);
 
     if (PyDateTime_Check(info.pParam))
         return GetDateTimeInfo(cur, index, info.pParam, info);

--- a/src/sqlwchar.cpp
+++ b/src/sqlwchar.cpp
@@ -207,9 +207,9 @@ void SQLWChar::dump()
 }
 
 
-SQLWCHAR* SQLWCHAR_FromUnicode(const Py_UNICODE* pch, Py_ssize_t len)
+SQLWCHAR* SQLWCHAR_FromUnicode(const Py_UNICODE* pch, Py_ssize_t len, int buff_len)
 {
-    SQLWCHAR* p = (SQLWCHAR*)pyodbc_malloc(sizeof(SQLWCHAR) * (len+1));
+    SQLWCHAR* p = (SQLWCHAR*)pyodbc_malloc(sizeof(SQLWCHAR) * (1 + max(len, buff_len)));
     if (p != 0)
     {
         if (!sqlwchar_copy(p, pch, len))

--- a/src/sqlwchar.h
+++ b/src/sqlwchar.h
@@ -57,6 +57,6 @@ extern Py_ssize_t SQLWCHAR_SIZE;
 // Allocate a new Unicode object, initialized from the given SQLWCHAR string.
 PyObject* PyUnicode_FromSQLWCHAR(const SQLWCHAR* sz, Py_ssize_t cch);
 
-SQLWCHAR* SQLWCHAR_FromUnicode(const Py_UNICODE* pch, Py_ssize_t len);
+SQLWCHAR* SQLWCHAR_FromUnicode(const Py_UNICODE* pch, Py_ssize_t len, int buff_len = -1);
 
 #endif // _PYODBCSQLWCHAR_H

--- a/tests2/freetdstests.py
+++ b/tests2/freetdstests.py
@@ -1229,6 +1229,10 @@ class FreeTDSTestCase(unittest.TestCase):
         self.cursor.execute('select 1')
         self.cursor.execute('select 1')
 
+    #
+    # callproc
+    #
+
     def test_callproc_output_varchar_int(self):
         self.cursor.execute('''
                             create procedure proc1
@@ -1361,11 +1365,6 @@ class FreeTDSTestCase(unittest.TestCase):
         v = pyodbc.SQLParameter(Decimal(), pyodbc.SQL_PARAM_OUTPUT)
         r = self.cursor.callproc('proc1', v)[0]
         self.assertEquals(r, Decimal('29.48'))
-
-        
-    # self.cursor.execute('''
-    #                     ''')
-    # self.cnxn.commit()
 
     def test_callproc_get_unicode(self):
         self.cursor.execute(u'''


### PR DESCRIPTION
So the callproc('f', (param1, param2, ...)) syntax is now available.
I also tested retrieving return values with cursor.fetchall(), and it just works.

I left some FIXMEs in the source code... the original pyodbc code supports python3, but it is definitely broken in this version...
